### PR TITLE
Fix VOC Class

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-air-1
-  version: "24.11.11.1"
+  version: "24.12.6.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
@@ -247,7 +247,7 @@ sensor:
     voc:
       name: "SEN55 VOC"
       id: sen55_voc
-      device_class: volatile_organic_compounds_parts
+      
       algorithm_tuning:
         #https://sensirion.com/media/documents/25AB572C/62B463AA/Sensirion_Engineering_Guidelines_SEN5x.pdf
         index_offset: 100


### PR DESCRIPTION
Version: 24.12.6.1

Adds:

Fixes:
- VOC Class on SEN55

Breaks:



Checks:
- [ ] Documentation Updated
- [ ] Build Number Incremented In AIR-1.yaml