### PR TITLE
fixes strapping pin warning for gpio9

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -136,6 +136,7 @@ binary_sensor:
       mode:
         input: true
         pullup: true
+      ignore_strapping_warning: true
     id: reset_button  
     on_press:
       then:


### PR DESCRIPTION
fixes strapping pin warning for gpio9

Version:

Adds:

Fixes:

Breaks:



Checks:
- [ ] Documentation Updated
- [ ] Build Number Incremented In AIR-1.yaml