### PR TITLE
[apollo_air-1] Add configurable DPS310 pressure offset

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-air-1
-  version: "25.12.18.2"
+  version: "26.2.24.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
@@ -104,7 +104,20 @@ number:
     update_interval: never
     step: 0.1
     mode: box
-  
+  - platform: template
+    name: "DPS310 Pressure Offset"
+    id: dps310_pressure_offset
+    restore_value: true
+    initial_value: 0.0
+    min_value: -100.0
+    max_value: 100.0
+    entity_category: "CONFIG"
+    unit_of_measurement: "hPa"
+    optimistic: true
+    update_interval: never
+    step: 0.1
+    mode: box
+
   - platform: template
     name: "Sleep Duration"
     id: deep_sleep_sleep_duration
@@ -212,6 +225,8 @@ sensor:
     pressure:
       name: "DPS310 Pressure"
       id: dps310pressure
+      filters:
+        - lambda: return x + id(dps310_pressure_offset).state;
     temperature:
       id: dps310temperature
     update_interval: 30s


### PR DESCRIPTION
Version: 26.2.24.1

## What does this implement/fix?

Adds a user-configurable pressure offset (`DPS310 Pressure Offset`) to the DPS310 sensor, following the same pattern already used for the SEN55 temperature and humidity offsets. The offset is exposed as a `number` entity (CONFIG category, ±100 hPa range, 0.1 hPa step, persists across reboots). A lambda filter applies it to the reported pressure value.

The SCD40's ambient pressure compensation source (`dps310pressure`) automatically benefits from the corrected value.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish

## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [x] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * DPS310 sensors now support pressure offset calibration, allowing adjustment of pressure readings within a -100.0 to 100.0 hPa range.

* **Updates**
  * Version updated to 26.2.24.1.
  * DPS310 sensor configuration enhanced to automatically apply offset corrections to pressure measurements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->