### PR TITLE
[apollo_air-1] Add configurable DPS310 pressure offset

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -228,8 +228,8 @@ sensor:
       id: dps310pressure
       filters:
         - lambda: |-
-          float offset = id(dps310_pressure_offset).state;
-          return isnan(offset) ? x : x + offset;
+            float offset = id(dps310_pressure_offset).state;
+            return isnan(offset) ? x : x + offset;
     temperature:
       id: dps310temperature
     update_interval: 30s


### PR DESCRIPTION
Version: 26.2.24.1

## What does this implement/fix?

Adds a user-configurable pressure offset (`DPS310 Pressure Offset`) to the DPS310 sensor, following the same pattern already used for the SEN55 temperature and humidity offsets. The offset is exposed as a `number` entity (CONFIG category, ±100 hPa range, 0.1 hPa step, persists across reboots). A lambda filter applies it to the reported pressure value.

The offset is applied in hPa (the sensor's native unit) regardless of how Home Assistant displays the value. The SCD40's ambient pressure compensation source (`dps310pressure`) automatically benefits from the corrected value.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish

## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested

If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a user-configurable pressure offset for DPS310 sensor readings (adjustable -100.0 to 100.0 hPa, default 0.0, 0.1 increments).
  * Offset is applied to reported pressure values and is persisted across restarts for consistent calibration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->