### PR TITLE
[aqi] Add NowCast AQI sensor using PM2.5 and PM10

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -313,6 +313,7 @@ sensor:
     pm_2_5: pm_2_5
     pm_10_0: pm_10_0
     calculation_type: AQI
+    device_class: aqi
 
   - platform: mics_4514
     id: mics4514


### PR DESCRIPTION
Version: 25.12.18.2

## What does this implement/fix?

Adds a **NowCast AQI** sensor to the AIR-1 using the built-in ESPHome `aqi` platform. The sensor takes PM2.5 and PM10 readings from the SEN55, computes an AQI sub-index for each using 2024 EPA breakpoints, and publishes the worse of the two values. The entity exposes `device_class: aqi` so Home Assistant formats and colours it correctly.

**Why "NowCast AQI" and not "AQI"?**

> A true US EPA Air Quality Index requires ozone (O₃) and sulfur dioxide (SO₂) sub-indices that the AIR-1 hardware does not measure. This value is computed from PM2.5 and PM10 only using the 2024 EPA breakpoints and should be understood as a particulate-matter air quality indicator, not a certified AQI reading.
>
> Reference: [EPA Technical Assistance Document for the Reporting of Daily Air Quality](https://document.airnow.gov/technical-assistance-document-for-the-reporting-of-daily-air-quailty.pdf)

The sensor is callback-driven — it updates the moment either PM sensor publishes a new reading, so no additional poll interval is needed and it adds no overhead to the `reportAllValues` script.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page