### PR TITLE
[version] Add ESPHome version and Apollo firmware version sensors

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -552,3 +552,4 @@ script:
       - component.update: pm2_5_to_4
       - component.update: pm4_to_10
       - component.update: voc_quality
+      - component.update: apollo_firmware_version


### PR DESCRIPTION
Version: 25.12.18.2

## What does this implement/fix?

Adds two diagnostic text sensors to `Core.yaml`, ported directly from [MTR-1 PR #79](https://github.com/ApolloAutomation/MTR-1/pull/79):

- **ESPHome Version** — exposes the running ESPHome version via the `version` platform (timestamp hidden)
- **Apollo Firmware Version** — exposes the `${version}` substitution variable as a diagnostic entity via the `template` platform

These sensors make firmware and ESPHome version visible in Home Assistant for diagnostics and automation without requiring any other changes.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [ ] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page