### PR TITLE
[esphome] Modernise board spec, web server v3, and API actions

### DIFF
--- a/Integrations/ESPHome/AIR-1.yaml
+++ b/Integrations/ESPHome/AIR-1.yaml
@@ -3,9 +3,6 @@ esphome:
   friendly_name: Apollo AIR-1
   comment: Apollo AIR-1
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.AIR-1"
     version: "${version}"

--- a/Integrations/ESPHome/AIR-1_BLE.yaml
+++ b/Integrations/ESPHome/AIR-1_BLE.yaml
@@ -3,9 +3,6 @@ esphome:
   friendly_name: Apollo AIR-1
   comment: Apollo AIR-1
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.AIR-1"
     version: "${version}"

--- a/Integrations/ESPHome/AIR-1_Factory.yaml
+++ b/Integrations/ESPHome/AIR-1_Factory.yaml
@@ -3,9 +3,6 @@ esphome:
   friendly_name: Apollo AIR-1
   comment: Apollo AIR-1 Factory
   name_add_mac_suffix: true
-  platformio_options:
-    board_build.flash_mode: dio
-
   project:
     name: "ApolloAutomation.AIR-1"
     version: "${version}"
@@ -52,11 +49,6 @@ esp32_improv:
   authorizer: none
 
 wifi:
-  on_connect:
-    - delay: 5s
-    - ble.disable:
-  on_disconnect:
-    - ble.enable:
   ap:
     ssid: "Apollo AIR1 Hotspot"
 

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -4,7 +4,8 @@ substitutions:
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:
-  board: esp32-c3-devkitm-1
+  variant: esp32c3
+  flash_size: 4MB
   framework:
     type: esp-idf
 
@@ -25,16 +26,16 @@ api:
               id(reportAllValues).execute();
           - deep_sleep.enter:
               id: deep_sleep_1
-  services:
-    #Co2 Calibration Service
-    - service: calibrate_co2_value
+  actions:
+    #Co2 Calibration Action
+    - action: calibrate_co2_value
       variables:
         co2_ppm: float
       then:
         - scd4x.perform_forced_calibration:
             value: !lambda "return co2_ppm;"
             id: scd40
-    - service: sen55_clean
+    - action: sen55_clean
       then:
         - sen5x.start_fan_autoclean: sen55
   reboot_timeout: 0s
@@ -43,6 +44,7 @@ captive_portal:
 
 web_server:
   port: 80
+  version: 3
 
 globals:
   - id: cycleCounter


### PR DESCRIPTION
Version: 25.12.18.2

## What does this implement/fix?

Ports the modernisation changes from [MTR-1 PR #74](https://github.com/ApolloAutomation/MTR-1/pull/74) to the AIR-1. All changes use newer ESPHome conventions and clean up legacy patterns.

**`Core.yaml`**
- `esp32`: replaced `board: esp32-c3-devkitm-1` with `variant: esp32c3` + `flash_size: 4MB` (new ESPHome board spec)
- `web_server`: added `version: 3`
- `api`: renamed `services:`/`service:` → `actions:`/`action:` for `calibrate_co2_value` and `sen55_clean`

**`AIR-1.yaml`, `AIR-1_BLE.yaml`, `AIR-1_Factory.yaml`**
- Removed `platformio_options: board_build.flash_mode: dio` (no longer needed with the new variant spec)

**`AIR-1_Factory.yaml`**
- Removed legacy `on_connect`/`on_disconnect` BLE enable/disable wifi hooks

Note: `min_version` was intentionally not changed.

## Types of changes

- [ ] Bugfix (fixed change that fixes an issue)
- [x] New feature (thanks!)
- [x] Breaking change (repair/feature that breaks existing functionality)
- [ ] Dependency Update - Does not publish
- [ ] Other - Does not publish
- [ ] Website of github readme file update - Does not publish
- [ ] Github workflows - Does not publish


## Checklist / Checklijst:

  - [x] The code change has been tested and works locally
  - [ ] The code change has not yet been tested
  
If user-visible functionality or configuration variables are added/modified:
  - [ ] Added/updated documentation for the web page