### PR TITLE
[readme] Replace static image with YouTube embed, update DPS310 to DPS368

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,8 @@ SCD40: CO2 and includes temperature and humidity sensing capabilities.
 
 SEN55: Particulate matter (PM1, PM2.5, PM10), VOCs, NOx, humidity, and temperature. 
 
+DPS368: Barometric air pressure and temperature.
+
 Dimensions & Design: 
 
 The AIR-1 measures just 61mm x 61mm x 30mm, and we have focused on efficient heat management within this small package to maintain sensor accuracy. This includes a thoughtful PCB layout and case design, incorporating ventilation and strategic component placement. 


### PR DESCRIPTION
Replace the static product image with a clickable YouTube thumbnail linking to the product video. Also removes the DPS310 sensor line as it is no longer part of the product.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * README badge replaced with a YouTube-linked thumbnail demonstrating the project.
  * Product label updated from "DPS310" to "DPS368" in visible docs and labels.
  * No other public-facing documentation changes included in this update.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->