### PR TITLE
fix: Apollo firmware version always showing unknown

### DIFF
--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -11,6 +11,7 @@ esp32:
 
 api:
   on_client_connected:
+    - component.update: apollo_firmware_version
     - delay: 90s
     - if:
         condition:


### PR DESCRIPTION
## Problem

The `Apollo Firmware Version` text sensor always shows **unknown** in Home Assistant, even after the device connects and appears online.

## Root Cause

The sensor uses `update_interval: never`, so it only publishes a value when `component.update: apollo_firmware_version` is explicitly called. That call only exists inside `reportAllValues` — but `reportAllValues` is gated behind the `else` branch of `on_client_connected`:

- If `prevent_sleep` OR `ota_mode` is ON → only prevents deep sleep, `reportAllValues` never runs
- If both are OFF → `reportAllValues` runs, then device sleeps

`prevent_sleep` has `restore_mode: RESTORE_DEFAULT_ON`, so it defaults to **ON** for any device in always-on mode (which is the common case). Result: `reportAllValues` never executes, the sensor never gets a value, and HA shows "unknown" indefinitely.

## Fix

Add `component.update: apollo_firmware_version` at the start of `on_client_connected`, before the 90s delay and the conditional. This fires unconditionally on every HA connection regardless of sleep mode.

```yaml
api:
  on_client_connected:
    - component.update: apollo_firmware_version  # ← added
    - delay: 90s
    - if: ...
```

The existing call in `reportAllValues` is kept as-is (harmless, provides an extra update on sleep-cycle wakes).

## Test Plan

- [ ] Flash to AIR-1 with `prevent_sleep` ON (default after first boot/factory reset)
- [ ] Confirm `Apollo Firmware Version` shows the version string in HA immediately after connecting
- [ ] Confirm same behavior with `prevent_sleep` OFF (sleep cycle mode)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Apollo firmware version refresh to ensure it updates when clients connect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->