### PR TITLE
Fix Apollo Firmware Version sensor blank on factory/BLE firmware

### DIFF
--- a/Integrations/ESPHome/AIR-1_BLE.yaml
+++ b/Integrations/ESPHome/AIR-1_BLE.yaml
@@ -11,6 +11,9 @@ esphome:
   on_boot:
     priority: 500
     then:
+      - text_sensor.template.publish:
+          id: apollo_firmware_version
+          state: "${version}"
       - lambda: |-
           id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 60 * 1000);
       - if:

--- a/Integrations/ESPHome/AIR-1_Factory.yaml
+++ b/Integrations/ESPHome/AIR-1_Factory.yaml
@@ -11,6 +11,9 @@ esphome:
   on_boot:
     - priority: 500
       then:
+        - text_sensor.template.publish:
+            id: apollo_firmware_version
+            state: "${version}"
         - lambda: |-
             id(deep_sleep_1).set_sleep_duration(id(deep_sleep_sleep_duration).state * 60 * 1000);
         - if:

--- a/Integrations/ESPHome/Core.yaml
+++ b/Integrations/ESPHome/Core.yaml
@@ -1,6 +1,6 @@
 substitutions:
   name: apollo-air-1
-  version: "26.3.2.1"
+  version: "26.6.10.1"
   device_description: ${name} made by Apollo Automation - version ${version}.
 
 esp32:


### PR DESCRIPTION
Version: 26.6.10.1

Adds:

Fixes:
- "Apollo Firmware Version" text sensor showing blank/unknown in Home Assistant and the web portal on shipped firmware (fixes #93). The `on_boot` publish added in #89 only went into `AIR-1.yaml`, but the published firmware is built from `AIR-1_Factory.yaml` (see `build.yml`), and `AIR-1_BLE.yaml` was also missed. This adds the same priority-500 `text_sensor.template.publish` to both files, matching the pattern already used in MSR-2's factory config.

Breaks:
- Nothing

Checks:
- [ ] Documentation Updated
- [x] Build Number Incremented In AIR-1.yaml

Verified with `esphome config` (2026.1.3): all three configs validate, and the merged Factory/BLE output now contains the `on_boot` publish with state `26.6.10.1`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Firmware version is now automatically published and accessible as a sensor on device startup.

* **Chores**
  * Updated system firmware version to 26.6.10.1.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->