### PR TITLE
Add managed firmware update system

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,6 +2,7 @@ name-template: 'Release v$NEXT_PATCH_VERSION'
 tag-template: "$RESOLVED_VERSION"
 change-template: "- #$NUMBER $TITLE @$AUTHOR"
 sort-direction: ascending
+category-template: '**$TITLE**'
 
 categories:
   - title: "🚨 Breaking changes"
@@ -26,11 +27,9 @@ include-labels:
 
 no-changes-template: '- No changes'
 
+# The shared build workflow appends a Full Changelog compare link to the
+# release body (release-drafter cannot render 4-part version tags).
 template: |
-  ## What's Changed
+  **What's Changed**
 
   $CHANGES
-
-  **Full Changelog**: https://github.com/ApolloAutomation/AIR-1/compare/$PREVIOUS_TAG...$RESOLVED_VERSION.1
-
-   Be sure to 🌟 this repository for updates!

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,8 @@ jobs:
       device-name: air-1
       yaml-files: |
         Integrations/ESPHome/AIR-1_Factory.yaml
-      firmware-names: "1_Factory:firmware"
+        Integrations/ESPHome/AIR-1_BLE.yaml
+      firmware-names: "1_Factory:firmware,1_BLE:firmware-ble"
       core-yaml-path: Integrations/ESPHome/Core.yaml
       esphome-version: stable
       # Bypass check if manually triggered with bypass option

--- a/Integrations/ESPHome/AIR-1.yaml
+++ b/Integrations/ESPHome/AIR-1.yaml
@@ -53,6 +53,8 @@ update:
     source: https://apolloautomation.github.io/AIR-1/firmware/manifest.json
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   ap:
     ssid: "Apollo AIR1 Hotspot"
 

--- a/Integrations/ESPHome/AIR-1.yaml
+++ b/Integrations/ESPHome/AIR-1.yaml
@@ -7,7 +7,7 @@ esphome:
     name: "ApolloAutomation.AIR-1"
     version: "${version}"
 
-  min_version: 2025.2.0
+  min_version: 2025.11.0
   on_boot:
     priority: 500
     then:

--- a/Integrations/ESPHome/AIR-1.yaml
+++ b/Integrations/ESPHome/AIR-1.yaml
@@ -38,6 +38,19 @@ ota:
   - platform: esphome
     id: ota_esphome
     password: ${ota_password}
+  - platform: http_request
+    id: ota_managed
+
+http_request:
+  verify_ssl: true
+
+safe_mode:
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: https://apolloautomation.github.io/AIR-1/firmware/manifest.json
 
 wifi:
   ap:

--- a/Integrations/ESPHome/AIR-1_BLE.yaml
+++ b/Integrations/ESPHome/AIR-1_BLE.yaml
@@ -7,7 +7,7 @@ esphome:
     name: "ApolloAutomation.AIR-1"
     version: "${version}"
 
-  min_version: 2025.2.0
+  min_version: 2025.11.0
   on_boot:
     priority: 500
     then:

--- a/Integrations/ESPHome/AIR-1_BLE.yaml
+++ b/Integrations/ESPHome/AIR-1_BLE.yaml
@@ -35,6 +35,19 @@ ota:
   - platform: esphome
     password: ${ota_password}
     id: ota_esphome
+  - platform: http_request
+    id: ota_managed
+
+http_request:
+  verify_ssl: true
+
+safe_mode:
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: https://apolloautomation.github.io/AIR-1/firmware-ble/manifest.json
 
 bluetooth_proxy:
   active: true

--- a/Integrations/ESPHome/AIR-1_BLE.yaml
+++ b/Integrations/ESPHome/AIR-1_BLE.yaml
@@ -56,6 +56,8 @@ esp32_ble_tracker:
     active: false
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   ap:
     ssid: "Apollo AIR1 Hotspot"
 

--- a/Integrations/ESPHome/AIR-1_Factory.yaml
+++ b/Integrations/ESPHome/AIR-1_Factory.yaml
@@ -7,7 +7,7 @@ esphome:
     name: "ApolloAutomation.AIR-1"
     version: "${version}"
 
-  min_version: 2025.2.0
+  min_version: 2025.11.0
   on_boot:
     - priority: 500
       then:

--- a/Integrations/ESPHome/AIR-1_Factory.yaml
+++ b/Integrations/ESPHome/AIR-1_Factory.yaml
@@ -62,6 +62,8 @@ esp32_improv:
   authorizer: none
 
 wifi:
+  on_connect:
+    - component.update: update_http_request
   ap:
     ssid: "Apollo AIR1 Hotspot"
 

--- a/Integrations/ESPHome/AIR-1_Factory.yaml
+++ b/Integrations/ESPHome/AIR-1_Factory.yaml
@@ -44,6 +44,19 @@ logger:
 ota:
   - platform: esphome
     id: ota_esphome
+  - platform: http_request
+    id: ota_managed
+
+http_request:
+  verify_ssl: true
+
+safe_mode:
+
+update:
+  - platform: http_request
+    id: update_http_request
+    name: Firmware Update
+    source: https://apolloautomation.github.io/AIR-1/firmware/manifest.json
 
 esp32_improv:
   authorizer: none


### PR DESCRIPTION
Ports the managed OTA update system from R_PRO-1 to all AIR-1 variants, so devices can self-update from the GitHub Pages manifests directly in Home Assistant.

## Changes

- `update: http_request` component (Firmware Update entity in HA) + `ota: http_request` platform on all three variants, pulling from the existing GitHub Pages manifests
- `safe_mode` for boot-loop recovery after a bad flash
- `http_request` with `verify_ssl: true` (esp-idf TLS, same as R_PRO-1)
- BLE variant is now built and published by CI to its own `firmware-ble/` manifest, and `AIR-1_BLE.yaml` updates from it — without this, a BLE device taking an update would be silently converted to the factory (non-BLE) firmware and lose Bluetooth proxy
- Manifest check triggered on `wifi.on_connect`: the update component's first 6-hour poll fires before the network is up and skips silently, leaving the entity stale for ~6h after every boot (R_PRO-1 has this today). The trigger makes the entity accurate within seconds of boot.
- `min_version` raised to 2025.11.0 to match the floor R_PRO-1 set when this system landed there

Deep-sleep note: prevent-sleep defaults on and the existing OTA-mode handling keeps the device awake during installs; for sleep-enabled units the on_connect check costs a couple of seconds of awake time per wake cycle.

Flash usage after the port (local compile, ESPHome 2026.1.3): AIR-1 66%, Factory 90.6%, BLE 93.6%.

## Testing

The identical port was tested end to end on a physical MTR-1 (factory and BLE manifest paths): flash → update offered in HA with release notes → OTA install from Pages → reboot on new version → Bluetooth proxy intact on the BLE variant. AIR-1 fork CI verified building and publishing both manifests; all three variants compile-verified locally.

Note for support: devices need outbound HTTPS (443) to `apolloautomation.github.io` — isolated IoT VLANs that block egress will show "up to date" forever with `ESP_ERR_HTTP_CONNECT` in debug logs.